### PR TITLE
クリックによる送信後のvalueの削除を可能にした

### DIFF
--- a/src/components/atoms/TextareaBox.tsx
+++ b/src/components/atoms/TextareaBox.tsx
@@ -1,12 +1,5 @@
-import {
-  FC,
-  ForwardRefExoticComponent,
-  PropsWithRef,
-} from "react";
+import { forwardRef } from "react";
 import style from "../../styles/components/atoms/TextareaBox.module.scss";
-
-export type ElementFrec<T extends keyof JSX.IntrinsicElements> =
-  ForwardRefExoticComponent<PropsWithRef<JSX.IntrinsicElements[T]>>;
 
 type Props = {
   onChange: (event: string) => void;
@@ -34,23 +27,28 @@ const defaultTextareaSettings: defaultTextareaSettingsType = {
   wrap: "soft",
 };
 
-const TextareaBox: FC<Props> = (props) => {
-  return (
-    <textarea
-      placeholder={props.placeholder}
-      disabled={props.disabled}
-      cols={props.cols}
-      rows={props.rows}
-      minLength={defaultTextareaSettings.minlength}
-      maxLength={defaultTextareaSettings.maxlength}
-      autoComplete={defaultTextareaSettings.autocomplete}
-      spellCheck={defaultTextareaSettings.spellcheck}
-      wrap={defaultTextareaSettings.wrap}
-      className={style.TextareaBox}
-      onChange={(e) => {
-        props.onChange(e.target.value);
-      }}
-    ></textarea>
-  );
-};
+type Ref = HTMLTextAreaElement;
+//any型のため要修正
+const TextareaBox = forwardRef<Ref, Props>(function InputTextarea(
+  props,
+  ref
+): any {
+  <textarea
+    minLength={defaultTextareaSettings.minlength}
+    maxLength={defaultTextareaSettings.maxlength}
+    autoComplete={defaultTextareaSettings.autocomplete}
+    spellCheck={defaultTextareaSettings.spellcheck}
+    wrap={defaultTextareaSettings.wrap}
+    placeholder={props.placeholder}
+    disabled={props.disabled}
+    cols={props.cols}
+    rows={props.rows}
+    className={style.TextareaBox}
+    onChange={(e) => {
+      props.onChange(e.target.value);
+    }}
+    ref={ref}
+  />;
+});
+
 export default TextareaBox;

--- a/src/components/molecules/MessageBox.tsx
+++ b/src/components/molecules/MessageBox.tsx
@@ -1,8 +1,8 @@
-import { FC } from "react";
-import style from '../../styles/components/molecules/MessageBox.module.scss';
+import { FC, useRef } from "react";
+import style from "../../styles/components/molecules/MessageBox.module.scss";
 import SendButton from "../atoms/SendButton";
 import TextareaBox from "../atoms/TextareaBox";
-import {  useState } from "react";
+import { useState } from "react";
 
 export type channeData = {
   id: string;
@@ -22,13 +22,12 @@ export type setTextarea = {
   rows: number;
 };
 
-
 const MessageBox: FC = () => {
   // API待ち
   const [disabled, setDisabled] = useState<boolean>(true);
   const [cols, setCols] = useState<number>(100);
   const [rows, setRows] = useState<number>(50);
-
+  const HTMLTextAreaElement = useRef<HTMLTextAreaElement>(null);
   let inputedMessage = "";
   const channel_name = "無法地帯";
   return (
@@ -39,11 +38,15 @@ const MessageBox: FC = () => {
         rows={rows}
         onChange={(mesage: string) => (inputedMessage = mesage)}
         placeholder={channel_name}
+        ref={HTMLTextAreaElement}
       />
 
       <SendButton
         onClick={() => {
+          //API待ち
           console.log(inputedMessage);
+          //割と不味いと思われる
+          HTMLTextAreaElement.current.value = "";
         }}
       />
     </div>


### PR DESCRIPTION
クリック後にHTMLTextAreaElement.current.value経由で ""を代入して削除を可能にした。
any型を使ってしまっているので要修正