### PR TITLE
fix/ Windowsでyarn installができない不具合の解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/markdown-it-emoji": "^2.0.2",
     "@types/react-infinite-scroller": "^1.2.2",
     "axios": "^0.21.1",
-    "emoji-mart": "git+https://github.com/Undecided-Discord/emoji-mart#master",
+    "emoji-mart": "git+https://github.com/Undecided-Discord/emoji-mart",
     "es-to-primitive": "^1.2.1",
     "markdown-it": "^12.2.0",
     "markdown-it-emoji": "^2.0.0",


### PR DESCRIPTION
- package.jsonのemoji-martからbranchの指定を消した